### PR TITLE
Only configure when a package is installed

### DIFF
--- a/libraries/provider_vmware_fusion.rb
+++ b/libraries/provider_vmware_fusion.rb
@@ -51,6 +51,7 @@ class Chef
       action :install do
         vmware_fusion_app new_resource.name do
           action :install
+          notifies :configure, "vmware_fusion_config[#{new_resource.name}]"
         end
       end
 
@@ -60,7 +61,7 @@ class Chef
       action :configure do
         vmware_fusion_config new_resource.name do
           license new_resource.license
-          action :configure
+          action :nothing
         end
       end
 

--- a/spec/libraries/provider_vmware_fusion_spec.rb
+++ b/spec/libraries/provider_vmware_fusion_spec.rb
@@ -40,6 +40,8 @@ describe Chef::Provider::VmwareFusion do
       p = provider
       expect(p).to receive(:vmware_fusion_app).with(name).and_yield
       expect(p).to receive(:action).with(:install)
+      expect(p).to receive(:notifies).with(:configure,
+                                           'vmware_fusion_config[default]')
       p.action_install
     end
   end
@@ -53,11 +55,11 @@ describe Chef::Provider::VmwareFusion do
     end
 
     shared_examples_for 'any resource' do
-      it 'uses a vmware_fusion_config to configure VMF' do
+      it 'uses a vmware_fusion_config resourceF' do
         p = provider
         expect(p).to receive(:vmware_fusion_config).with(name).and_yield
         expect(p).to receive(:license).with(license)
-        expect(p).to receive(:action).with(:configure)
+        expect(p).to receive(:action).with(:nothing)
         p.action_configure
       end
     end


### PR DESCRIPTION
There's seemingly no way to check whether the given key is already configured, making the config resource not necessarily idempotent. :(