### PR TITLE
Support a source attribute for specific package paths

### DIFF
--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -1,8 +1,6 @@
 ---
 driver:
-  name: digitalocean
+  name: localhost
 
 platforms:
   - name: macosx
-    driver:
-      name: localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: objective-c
 
+branches:
+  only:
+    - master
+
 install:
   - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
-  - chef exec bundle install --without=development integration
+  - chef exec bundle update
 
 before_script:
-  # Pending ENV support in Kitchen's Rake tasks and not just the CLI
   - cp .kitchen.travis.yml .kitchen.local.yml
 
 script:
-  - chef exec rake && chef exec kitchen test
+  - chef exec bundle exec rake && chef exec bundle exec kitchen test -c 2
 
 after_script:
 
 env:
   global:
-    # - KITCHEN_LOCAL_YAML=.kitchen.travis.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ VMware Fusion Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Support a `source` attribute for specific .dmg package paths
 
 v0.1.1 (2015-08-01)
 -------------------

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Recipes
 
 ***default***
 
-Installs VMware Fusion with an optional license key attribute.
+Installs VMware Fusion with optional license key and/or package source
+attributes.
 
 Attributes
 ==========
@@ -38,6 +39,11 @@ Attributes
 An optional license key can be passed in to be configured during the Chef run:
 
     default['vmware_fusion']['license'] = nil
+
+An optional path to a VMWare Fusion .dmg file can be provided to install
+instead of downloading the package from VMware's site.
+
+    default['vmware_fusion']['source'] = nil
 
 Resources
 =========
@@ -50,6 +56,7 @@ Syntax:
 
     vmware_fusion 'default' do
       license 'abc123'
+      source '/path/to/vmware.dmg'
       action :install
     end
 
@@ -63,10 +70,11 @@ Actions:
 
 Attributes:
 
-| Attribute  | Default        | Description             |
-|------------|----------------|-------------------------|
-| license    | `nil`          | An optional license key |
-| action     | `:install`     | Action(s) to perform    |
+| Attribute  | Default        | Description                            |
+|------------|----------------|----------------------------------------|
+| license    | `nil`          | An optional license key                |
+| source     | `nil`          | An optional path to a VMware .dmg file |
+| action     | `:install`     | Action(s) to perform                   |
 
 ***vmware_fusion_app***
 
@@ -75,6 +83,7 @@ Used to manage the installation of the VMware Fusion app.
 Syntax:
 
     vmware_fusion_app 'default' do
+      source '/path/to/vmware.dmg'
       action :install
     end
 
@@ -87,9 +96,10 @@ Actions:
 
 Attributes:
 
-| Attribute  | Default        | Description             |
-|------------|----------------|-------------------------|
-| action     | `:install`     | Action(s) to perform    |
+| Attribute  | Default        | Description                            |
+|------------|----------------|----------------------------------------|
+| source     | `nil`          | An optional path to a VMware .dmg file |
+| action     | `:install`     | Action(s) to perform                   |
 
 ***vmware_fusion_config***
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,4 @@
 #
 
 default['vmware_fusion']['license'] = nil
+default['vmware_fusion']['source'] = nil

--- a/libraries/provider_vmware_fusion.rb
+++ b/libraries/provider_vmware_fusion.rb
@@ -50,6 +50,7 @@ class Chef
       #
       action :install do
         vmware_fusion_app new_resource.name do
+          source new_resource.source
           action :install
         end
       end

--- a/libraries/provider_vmware_fusion_app.rb
+++ b/libraries/provider_vmware_fusion_app.rb
@@ -79,7 +79,7 @@ class Chef
       # @return [String] a remote package URL
       #
       def package_source
-        @package_source ||= begin
+        @package_source ||= new_resource.source || begin
           u = URI.parse(URL)
           opts = { use_ssl: u.scheme == 'https',
                    ca_file: Chef::Config[:ssl_ca_file] }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,4 +20,5 @@
 
 vmware_fusion 'default' do
   license node['vmware_fusion']['license']
+  source node['vmware_fusion']['source']
 end

--- a/spec/libraries/provider_vmware_fusion_app_spec.rb
+++ b/spec/libraries/provider_vmware_fusion_app_spec.rb
@@ -69,6 +69,12 @@ describe Chef::Provider::VmwareFusionApp do
 
   describe '#package_source' do
     let(:location) { 'https://example.com/vmwf.dmg' }
+    let(:source) { nil }
+    let(:new_resource) do
+      r = super()
+      r.source(source) unless source.nil?
+      r
+    end
 
     before(:each) do
       caf = Chef::Config[:ssl_ca_file]
@@ -77,9 +83,21 @@ describe Chef::Provider::VmwareFusionApp do
         .and_return('location' => location)
     end
 
-    it 'returns a download URL' do
-      expected = 'https://example.com/vmwf.dmg'
-      expect(provider.send(:package_source)).to eq(expected)
+    context 'an all-default resource' do
+      let(:source) { nil }
+
+      it 'returns a download URL' do
+        expected = 'https://example.com/vmwf.dmg'
+        expect(provider.send(:package_source)).to eq(expected)
+      end
+    end
+
+    context 'a resource with a given source path' do
+      let(:source) { '/path/to/vmware.dmg' }
+
+      it 'returns the source path' do
+        expect(provider.send(:package_source)).to eq('/path/to/vmware.dmg')
+      end
     end
   end
 end

--- a/spec/libraries/provider_vmware_fusion_spec.rb
+++ b/spec/libraries/provider_vmware_fusion_spec.rb
@@ -36,11 +36,31 @@ describe Chef::Provider::VmwareFusion do
   end
 
   describe '#action_install' do
-    it 'uses a vmware_fusion_app to install VMF' do
-      p = provider
-      expect(p).to receive(:vmware_fusion_app).with(name).and_yield
-      expect(p).to receive(:action).with(:install)
-      p.action_install
+    let(:source) { nil }
+    let(:new_resource) do
+      r = super()
+      r.source(source) unless source.nil?
+      r
+    end
+
+    shared_examples_for 'any resource' do
+      it 'uses a vmware_fusion_app to install VMF' do
+        p = provider
+        expect(p).to receive(:vmware_fusion_app).with(name).and_yield
+        expect(p).to receive(:source).with(source)
+        expect(p).to receive(:action).with(:install)
+        p.action_install
+      end
+    end
+
+    context 'an all-default resource' do
+      it_behaves_like 'any resource'
+    end
+
+    context 'a resource with a given source path' do
+      let(:source) { '/path/to/vmware.dmg' }
+
+      it_behaves_like 'any resource'
     end
   end
 

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -3,37 +3,41 @@
 require_relative '../spec_helper'
 
 describe 'vmware-fusion::default' do
-  let(:overrides) { nil }
+  let(:overrides) { {} }
   let(:runner) do
     ChefSpec::SoloRunner.new do |node|
-      overrides && overrides.each { |k, v| node.set['vmware_fusion'][k] = v }
+      overrides.each { |k, v| node.set['vmware_fusion'][k] = v }
     end
   end
   let(:chef_run) { runner.converge(described_recipe) }
 
-  context 'all default attributes' do
-    let(:overrides) { nil }
-
+  shared_examples_for 'any attribute set' do
     it 'installs VMWare Fusion' do
-      expect(chef_run).to install_vmware_fusion('default').with(license: nil)
+      expect(chef_run).to install_vmware_fusion('default')
+        .with(license: overrides[:license], source: overrides[:source])
     end
 
     it 'configures VMware Fusion' do
-      expect(chef_run).to configure_vmware_fusion('default').with(license: nil)
+      expect(chef_run).to configure_vmware_fusion('default')
+        .with(license: overrides[:license], source: overrides[:source])
     end
+  end
+
+  context 'all default attributes' do
+    let(:overrides) { {} }
+
+    it_behaves_like 'any attribute set'
   end
 
   context 'an overridden license attribute' do
     let(:overrides) { { license: 'abc123' } }
 
-    it 'installs VMware Fusion' do
-      expect(chef_run).to install_vmware_fusion('default')
-        .with(license: 'abc123')
-    end
+    it_behaves_like 'any attribute set'
+  end
 
-    it 'configures VMware Fusion' do
-      expect(chef_run).to configure_vmware_fusion('default')
-        .with(license: 'abc123')
-    end
+  context 'an overridden source attribute' do
+    let(:overrides) { { source: '/path/to/vmware.dmg' } }
+
+    it_behaves_like 'any attribute set'
   end
 end


### PR DESCRIPTION
The app resources were accepting the attribute already, but not doing anything with it in the providers.