### PR TITLE
Update unit tests for Chef 12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ branches:
 
 install:
   - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
-  - chef exec bundle update
+  - chef exec bundle install --without=development integration
 
 before_script:
   - cp .kitchen.travis.yml .kitchen.local.yml
 
 script:
-  - chef exec bundle exec rake && chef exec bundle exec kitchen test -c 2
+  - chef exec rake && chef exec kitchen test
 
 after_script:
 

--- a/spec/libraries/provider_vmware_fusion_app_spec.rb
+++ b/spec/libraries/provider_vmware_fusion_app_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_vmware_fusion_app'
 
 describe Chef::Provider::VmwareFusionApp do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::VmwareFusionApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::VmwareFusionApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'URL' do
     it 'returns the remote URL' do

--- a/spec/libraries/provider_vmware_fusion_config_spec.rb
+++ b/spec/libraries/provider_vmware_fusion_config_spec.rb
@@ -5,8 +5,11 @@ require_relative '../../libraries/provider_vmware_fusion_config'
 
 describe Chef::Provider::VmwareFusionConfig do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::VmwareFusionConfig.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) do
+    Chef::Resource::VmwareFusionConfig.new(name, run_context)
+  end
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_vmware_fusion_spec.rb
+++ b/spec/libraries/provider_vmware_fusion_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_vmware_fusion'
 
 describe Chef::Provider::VmwareFusion do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::VmwareFusion.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::VmwareFusion.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'PATH' do
     it 'returns the app directory' do


### PR DESCRIPTION
`Chef::Provider.new` no longer accepts `nil` as a valid run_context.